### PR TITLE
Fix condition on import of WiX targets file

### DIFF
--- a/Source/Applications/MiMDSetup/MiMDSetup.wixproj
+++ b/Source/Applications/MiMDSetup/MiMDSetup.wixproj
@@ -79,7 +79,7 @@
     <WixTargetsPath>$(WixToolPath)wix.targets</WixTargetsPath>
     <WixTasksPath>$(WixToolPath)WixTasks.dll</WixTasksPath>
   </PropertyGroup>
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(WixTargetsPath)" Condition="Exists($(WixTargetsPath))" />
   <PropertyGroup>
     <PreBuildEvent>"$(WixToolPath)heat.exe" dir "$(SolutionDir)Applications\MiMD\wwwroot" -cg MiMDWebFiles -dr WWWROOTFOLDER -gg -sfrag -srd -sreg -var var.MiMDSource -out "$(SolutionDir)\Applications\MiMDSetup\MiMDWebFiles.wxs"</PreBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
Without this condition, the project will fail to load if you haven't restored NuGet packages. But if the project fails to load, you cannot restore its NuGet packages.

You do have to reload the project after restoring NuGet packages, but it's a Catch-22 otherwise.