### PR TITLE
miMD-14 Fix Table Filtering

### DIFF
--- a/Source/Applications/MiMD/wwwroot/Scripts/TSX/MiMD/PRC-002/MeterWizzard/SelectMeter.tsx
+++ b/Source/Applications/MiMD/wwwroot/Scripts/TSX/MiMD/PRC-002/MeterWizzard/SelectMeter.tsx
@@ -52,7 +52,7 @@ const SelectMeter = (props: IProps) => {
 
     React.useEffect(() => {
         getMeters();
-    }, [meterFilter]);
+    }, [meterFilter, meterAsc, meterSort]);
 
     React.useEffect(() => {
         const handle = getAdditionalFields();
@@ -63,21 +63,13 @@ const SelectMeter = (props: IProps) => {
     }, []);
 
     function getMeters() {
-        const fields = standardSearch.map(s => s.key);
-        const searches = meterFilter.map(search => {
-            if (fields.findIndex(item => item == search.FieldName) == -1)
-                return { ...search, IsPivotColumn: true }
-            else return search;
-        });
-
-        searches.push({
+        const searches = [{
             FieldName: 'ID',
             SearchText: ' (SELECT MeterID FROM [MiMD.ComplianceMeter])',
             Operator: 'NOT IN',
             Type: 'query',
             IsPivotColumn: false
-        });
-
+        }]
         searches.push(...meterFilter);
 
         setSearchState('Loading');
@@ -92,9 +84,7 @@ const SelectMeter = (props: IProps) => {
         });
 
         handle.done((data) => {
-            const res = JSON.parse(data);
-            const sortedData = _.orderBy(res, [meterSort], [meterAsc]);
-            setMeterList(sortedData);
+            setMeterList(JSON.parse(data));
             setSearchState('Idle');
         });
         handle.fail(() => { setSearchState('Error'); })

--- a/Source/Applications/MiMD/wwwroot/Scripts/TSX/MiMD/PRC-002/MeterWizzard/SelectMeter.tsx
+++ b/Source/Applications/MiMD/wwwroot/Scripts/TSX/MiMD/PRC-002/MeterWizzard/SelectMeter.tsx
@@ -49,44 +49,44 @@ const SelectMeter = (props: IProps) => {
 
     const [filterableList, setFilterableList] = React.useState<Array<Search.IField<MiMD.Meter>>>(standardSearch);
     const [searchState, setSearchState] = React.useState<('Idle' | 'Loading' | 'Error')>('Idle');
-    
+
     React.useEffect(() => {
         setSearchState('Loading');
-        const handleMeterList = getMeterList();
-        
-        return () => {
-            if (handleMeterList != null && handleMeterList.abort != null) handleMeterList.abort();
-        }
-    }, [props, meterAsc, meterSort, meterFilter]);
-
-    function getMeterList(): JQuery.jqXHR<Array<PRC002.IMeter>> {
-        const nativeFields = standardSearch.map(s => s.key);
-
-        const searches = meterFilter.map(s => { if (nativeFields.findIndex(item => item == s.FieldName) == -1) return { ...s, IsPivotColumn: true }; else return s; });
-        searches.push({
-            FieldName: 'ID',
-            SearchText: ' (SELECT MeterID FROM [MiMD.ComplianceMeter])',
-            Operator: 'NOT IN',
-            Type: 'query',
-            IsPivotColumn: false
-        });
         const handle = $.ajax({
-            type: "POST",
-            url: `${homePath}api/MiMD/PRC002/ComplianceMeter/SearchableList`,
+            type: "GET",
+            url: `${homePath}api/MiMD/Meter/SearchableList`,
             contentType: "application/json; charset=utf-8",
             dataType: 'json',
-            data: JSON.stringify({ Searches: searches, OrderBy: meterSort, Ascending: meterAsc }),
             cache: false,
             async: true
         });
 
-        handle.done((data: string) => {
-            setMeterList(JSON.parse(data));
+        handle.done((data) => {
+            const sortedData = _.orderBy(data, [meterSort], [meterAsc]);
+            setMeterList(sortedData);
             setSearchState('Idle');
         });
         handle.fail(() => { setSearchState('Error'); })
-        return handle;
-    }
+        if (handle != null && handle.abort != null) handle.abort();
+    }, []);
+
+    React.useEffect(() => {
+        setSearchState('Loading');
+        const handle = $.ajax({
+            type: "POST",
+            url: `${homePath}api/MiMD/Meter/SearchableList`,
+            contentType: "application/json; charset=utf-8",
+            dataType: 'json',
+            data: JSON.stringify({ Searches: meterFilter, OrderBy: meterSort, Ascending: meterAsc }),
+            cache: false,
+            async: true
+        })
+        .done((result) => {
+            setMeterList(JSON.parse(result));
+            setSearchState('Idle');
+        }).fail(() => setSearchState('Error'));
+        return () => { if (handle != null && handle?.abort != null) handle.abort(); }
+    }, [meterFilter]);
 
     React.useEffect(() => {
         const handle = getAdditionalFields();
@@ -156,16 +156,22 @@ const SelectMeter = (props: IProps) => {
                     SortKey={meterSort}
                     Ascending={meterAsc}
                     OnSort={(d) => {
-                        if (d.colField == meterSort) setMeterAsc(!meterAsc);
+                        if (d.colField == meterSort) {
+                            setMeterAsc(!meterAsc);
+                            const ordered = _.orderBy(MeterList, [d.colKey], [(!meterAsc ? "asc" : "desc")]);
+                            setMeterList(ordered);
+                        }
                         else {
-                            setMeterSort(d.colField);
                             setMeterAsc(true);
+                            setMeterSort(d.colField);
+                            const ordered = _.orderBy(MeterList, [d.colKey], ["asc"]);
+                            setMeterList(ordered);
                         }
                     }}
                     OnClick={(d) => { props.setMeter(d.row); }}
-                    TheadStyle={{ fontSize: 'smaller', display: 'table', tableLayout: 'fixed', width: '100%' }}
-                    TbodyStyle={{ display: 'block', overflowY: 'scroll', maxHeight: 330, width: '100%' }}
-                    RowStyle={{ fontSize: 'smaller', display: 'table', tableLayout: 'fixed', width: '100%' }}
+                    TheadStyle={{ fontSize: 'smaller' }}
+                    TbodyStyle={{ display: 'block' }}
+                    RowStyle={{ fontSize: 'smaller' }}
                     Selected={(item) => item.ID === (props.selectedMeter == undefined ? -1 : props.selectedMeter.ID)}
                     KeySelector={item => item.ID}
                 >

--- a/Source/Applications/MiMD/wwwroot/Scripts/TSX/MiMD/PRC-002/MeterWizzard/SelectMeter.tsx
+++ b/Source/Applications/MiMD/wwwroot/Scripts/TSX/MiMD/PRC-002/MeterWizzard/SelectMeter.tsx
@@ -154,14 +154,10 @@ const SelectMeter = (props: IProps) => {
                     OnSort={(d) => {
                         if (d.colField == meterSort) {
                             setMeterAsc(!meterAsc);
-                            const ordered = _.orderBy(MeterList, [d.colKey], [(!meterAsc ? "asc" : "desc")]);
-                            setMeterList(ordered);
                         }
                         else {
                             setMeterAsc(true);
                             setMeterSort(d.colField);
-                            const ordered = _.orderBy(MeterList, [d.colKey], ["asc"]);
-                            setMeterList(ordered);
                         }
                     }}
                     OnClick={(d) => { props.setMeter(d.row); }}


### PR DESCRIPTION
### Description
The current table was not accessing the correct db for the meter select/meter wizard. This has been fixed so it now points to the Meter Table and filters out the meters in use.

#### Testing
1. Open miMD
2. Go to PRC002 tab
3. Select New Meter Button
4. verify table filters out already in use meters and search works and filtering works 